### PR TITLE
Fix CSS inlining to only apply when inline styles are present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +548,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "css-inline"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28b595ccb4e7e622ce8b18ce101bb44dd5f48579cab690af88c1e55a690b9b9"
+dependencies = [
+ "cssparser 0.31.2",
+ "html5ever",
+ "indexmap",
+ "lru",
+ "pico-args",
+ "rayon",
+ "reqwest",
+ "rustc-hash",
+ "selectors",
+ "smallvec",
+ "url",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.2",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,7 +588,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.2",
  "smallvec",
 ]
 
@@ -560,7 +598,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
 dependencies = [
- "cssparser",
+ "cssparser 0.33.0",
 ]
 
 [[package]]
@@ -578,6 +616,17 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
 
 [[package]]
 name = "displaydoc"
@@ -687,12 +736,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -743,6 +808,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -811,6 +885,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -832,6 +911,20 @@ dependencies = [
  "css-compare",
  "htmlparser",
  "similar-asserts",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1184,7 +1277,7 @@ dependencies = [
  "ahash",
  "bitflags",
  "const-str",
- "cssparser",
+ "cssparser 0.33.0",
  "cssparser-color",
  "data-encoding",
  "getrandom",
@@ -1231,6 +1324,35 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
 
 [[package]]
 name = "matchers"
@@ -1329,6 +1451,7 @@ dependencies = [
  "async-trait",
  "concat-idents",
  "criterion",
+ "css-inline",
  "enum-as-inner",
  "enum_dispatch",
  "html-compare",
@@ -1383,6 +1506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,10 +1564,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7645c578d3a5c4cdf667af1ad39765f5f751c4883d251e050d5e1204b5cad0a9"
 dependencies = [
  "bitflags",
- "cssparser",
+ "cssparser 0.33.0",
  "log",
- "phf",
- "phf_codegen",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
  "precomputed-hash",
  "rustc-hash",
  "smallvec",
@@ -1487,12 +1616,31 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -1501,8 +1649,18 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
 ]
 
 [[package]]
@@ -1511,7 +1669,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.2",
  "rand",
 ]
 
@@ -1521,11 +1679,20 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
  "syn 2.0.91",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1536,6 +1703,12 @@ checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
 
 [[package]]
 name = "pin-project-lite"
@@ -1982,6 +2155,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags",
+ "cssparser 0.31.2",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2247,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2145,6 +2346,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.2",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,6 +2429,17 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
 
 [[package]]
 name = "thiserror"
@@ -2536,6 +2773,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/packages/mrml-core/Cargo.toml
+++ b/packages/mrml-core/Cargo.toml
@@ -55,6 +55,7 @@ url = { version = "2.5", optional = true }
 itertools = { version = "0.13" }
 enum_dispatch = { version = "0.3", optional = true }
 enum-as-inner = { version = "0.6", optional = true }
+css-inline = "0.14.4"
 
 [dev-dependencies]
 concat-idents = "1.1"

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -236,12 +236,68 @@ impl Renderer<'_, MjHead, ()> {
             cursor.buffer.push_str("</style>");
         }
 
-        // TODO this should be optional
-        cursor.buffer.push_str("<style type=\"text/css\">");
-        for item in self.mj_style_iter() {
-            cursor.buffer.push_str(item);
+        // Group styles by inline attribute
+        let mapped_styles: Vec<(&str, bool)> = self
+            .mj_style_iter()
+            .map(|style_content| {
+                let mj_style = self
+                    .element
+                    .children
+                    .iter()
+                    .find_map(|child| {
+                        child
+                            .as_mj_style()
+                            .filter(|s| s.children.trim() == style_content)
+                    })
+                    .or_else(|| {
+                        self.element
+                            .children
+                            .iter()
+                            .filter_map(|child| child.as_mj_include())
+                            .flat_map(|include| include.0.children.iter())
+                            .find_map(|child| {
+                                child
+                                    .as_mj_style()
+                                    .filter(|s| s.children.trim() == style_content)
+                            })
+                    });
+
+                (
+                    style_content,
+                    mj_style.map(|s| s.is_inline()).unwrap_or(false),
+                )
+            })
+            .collect();
+
+        let (inline_styles, non_inline_styles): (Vec<_>, Vec<_>) =
+            mapped_styles.iter().partition(|(_, is_inline)| *is_inline);
+
+        // Set the flag if there are any inline styles
+        if !inline_styles.is_empty() {
+            cursor.header.set_has_inline_styles(true);
         }
-        cursor.buffer.push_str("</style>");
+
+        // Render inline styles
+        if !inline_styles.is_empty() {
+            cursor.buffer.push_str("<style type=\"text/css\">");
+            for (style, _) in inline_styles {
+                cursor.buffer.push_str(style);
+            }
+            cursor.buffer.push_str("</style>");
+        }
+
+        // Render non-inline styles
+        if !non_inline_styles.is_empty() {
+            cursor.buffer.push_str("<style type=\"text/css\"");
+            if cursor.header.has_inline_styles() {
+                cursor.buffer.push_str(" data-css-inline=\"ignore\"");
+            }
+            cursor.buffer.push_str(">");
+            for (style, _) in non_inline_styles {
+                cursor.buffer.push_str(style);
+            }
+            cursor.buffer.push_str("</style>");
+        }
     }
 
     fn render_raw(&self, cursor: &mut RenderCursor) -> Result<(), Error> {

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -120,36 +120,43 @@ fn render_font_link(target: &mut String, href: &str) {
 }
 
 impl Renderer<'_, MjHead, ()> {
-    fn mj_style_iter(&self) -> impl Iterator<Item = &str> {
+    fn mj_style_iter(&self) -> impl Iterator<Item = (&str, bool)> {
         self.element.children.iter().flat_map(|item| {
-            item.as_mj_include()
+            // Include styles from mj_include elements
+            let included_styles = item.as_mj_include().into_iter().flat_map(|inner| {
+                let includes_css = inner
+                    .0
+                    .children
+                    .iter()
+                    .filter_map(|child| child.as_mj_style())
+                    .map(|child| (child.children.trim(), child.is_inline()));
+
+                let direct_css = inner
+                    .0
+                    .attributes
+                    .kind
+                    .is_css(false)
+                    .then(|| {
+                        inner
+                            .0
+                            .children
+                            .iter()
+                            .filter_map(|item| item.as_text())
+                            .map(|text| (text.inner_str().trim(), false))
+                    })
+                    .into_iter()
+                    .flatten();
+
+                includes_css.chain(direct_css)
+            });
+
+            // Direct mj_style elements
+            let direct_styles = item
+                .as_mj_style()
                 .into_iter()
-                .flat_map(|inner| {
-                    inner
-                        .0
-                        .children
-                        .iter()
-                        .filter_map(|child| child.as_mj_style())
-                        .map(|child| child.children.trim())
-                })
-                .chain(
-                    item.as_mj_include()
-                        .into_iter()
-                        .filter(|child| child.0.attributes.kind.is_css(false))
-                        .flat_map(|child| {
-                            child
-                                .0
-                                .children
-                                .iter()
-                                .filter_map(|item| item.as_text())
-                                .map(|text| text.inner_str().trim())
-                        }),
-                )
-                .chain(
-                    item.as_mj_style()
-                        .into_iter()
-                        .map(|item| item.children.trim()),
-                )
+                .map(|style| (style.children.trim(), style.is_inline()));
+
+            included_styles.chain(direct_styles)
         })
     }
 
@@ -228,39 +235,10 @@ impl Renderer<'_, MjHead, ()> {
     }
 
     fn render_styles(&self, cursor: &mut RenderCursor) {
-        // Group styles by inline attribute
-        let mapped_styles: Vec<(&str, bool)> = self
-            .mj_style_iter()
-            .map(|style_content| {
-                let mj_style = self
-                    .element
-                    .children
-                    .iter()
-                    .find_map(|child| {
-                        child
-                            .as_mj_style()
-                            .filter(|s| s.children.trim() == style_content)
-                    })
-                    .or_else(|| {
-                        self.element
-                            .children
-                            .iter()
-                            .filter_map(|child| child.as_mj_include())
-                            .flat_map(|include| include.0.children.iter())
-                            .find_map(|child| {
-                                child
-                                    .as_mj_style()
-                                    .filter(|s| s.children.trim() == style_content)
-                            })
-                    });
+        // Get all styles with their inline status
+        let mapped_styles: Vec<(&str, bool)> = self.mj_style_iter().collect();
 
-                (
-                    style_content,
-                    mj_style.map(|s| s.is_inline()).unwrap_or(false),
-                )
-            })
-            .collect();
-
+        // Partition into inline and non-inline styles
         let (inline_styles, non_inline_styles): (Vec<_>, Vec<_>) =
             mapped_styles.iter().partition(|(_, is_inline)| *is_inline);
 
@@ -283,7 +261,7 @@ impl Renderer<'_, MjHead, ()> {
         // Render inline styles
         if has_inline_styles {
             cursor.buffer.push_str("<style type=\"text/css\">");
-            for (style, _) in inline_styles {
+            for (style, _) in &inline_styles {
                 cursor.buffer.push_str(style);
             }
             cursor.buffer.push_str("</style>");
@@ -298,7 +276,7 @@ impl Renderer<'_, MjHead, ()> {
             cursor.buffer.push_str(">");
 
             // Add non-inline styles from mj_style elements
-            for (style, _) in non_inline_styles {
+            for (style, _) in &non_inline_styles {
                 cursor.buffer.push_str(style);
             }
 

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -228,14 +228,6 @@ impl Renderer<'_, MjHead, ()> {
     }
 
     fn render_styles(&self, cursor: &mut RenderCursor) {
-        if !cursor.header.styles().is_empty() {
-            cursor.buffer.push_str("<style type=\"text/css\">");
-            for style in cursor.header.styles().iter() {
-                cursor.buffer.push_str(style);
-            }
-            cursor.buffer.push_str("</style>");
-        }
-
         // Group styles by inline attribute
         let mapped_styles: Vec<(&str, bool)> = self
             .mj_style_iter()
@@ -272,13 +264,24 @@ impl Renderer<'_, MjHead, ()> {
         let (inline_styles, non_inline_styles): (Vec<_>, Vec<_>) =
             mapped_styles.iter().partition(|(_, is_inline)| *is_inline);
 
+        // Clone header styles to avoid borrowing issues
+        let header_styles: Vec<String> = cursor
+            .header
+            .styles()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        // Check if there are inline styles
+        let has_inline_styles = !inline_styles.is_empty();
+
         // Set the flag if there are any inline styles
-        if !inline_styles.is_empty() {
+        if has_inline_styles {
             cursor.header.set_has_inline_styles(true);
         }
 
         // Render inline styles
-        if !inline_styles.is_empty() {
+        if has_inline_styles {
             cursor.buffer.push_str("<style type=\"text/css\">");
             for (style, _) in inline_styles {
                 cursor.buffer.push_str(style);
@@ -287,15 +290,23 @@ impl Renderer<'_, MjHead, ()> {
         }
 
         // Render non-inline styles
-        if !non_inline_styles.is_empty() {
+        if !non_inline_styles.is_empty() || !header_styles.is_empty() {
             cursor.buffer.push_str("<style type=\"text/css\"");
-            if cursor.header.has_inline_styles() {
+            if has_inline_styles {
                 cursor.buffer.push_str(" data-css-inline=\"ignore\"");
             }
             cursor.buffer.push_str(">");
+
+            // Add non-inline styles from mj_style elements
             for (style, _) in non_inline_styles {
                 cursor.buffer.push_str(style);
             }
+
+            // Add additional styles from header
+            for style in &header_styles {
+                cursor.buffer.push_str(style);
+            }
+
             cursor.buffer.push_str("</style>");
         }
     }

--- a/packages/mrml-core/src/mj_style/mod.rs
+++ b/packages/mrml-core/src/mj_style/mod.rs
@@ -30,7 +30,10 @@ pub type MjStyle = Component<PhantomData<MjStyleTag>, MjStyleAttributes, String>
 
 impl MjStyle {
     pub fn is_inline(&self) -> bool {
-        matches!(self.attributes.inline.as_deref(), Some("inline"))
+        matches!(
+            self.attributes.inline.as_deref(),
+            Some("inline") | Some("true")
+        )
     }
 
     pub fn children(&self) -> &str {

--- a/packages/mrml-core/src/prelude/render/header.rs
+++ b/packages/mrml-core/src/prelude/render/header.rs
@@ -10,6 +10,7 @@ pub(crate) struct VariableHeader {
     used_font_families: Set<String>,
     media_queries: Map<String, Size>,
     styles: Set<Cow<'static, str>>,
+    has_inline_styles: bool,
 }
 
 impl Default for VariableHeader {
@@ -18,6 +19,7 @@ impl Default for VariableHeader {
             used_font_families: Default::default(),
             media_queries: Map::new(),
             styles: Set::new(),
+            has_inline_styles: false,
         }
     }
 }
@@ -68,6 +70,14 @@ impl VariableHeader {
         if let Some(value) = value {
             self.add_style(value);
         }
+    }
+
+    pub fn has_inline_styles(&self) -> bool {
+        self.has_inline_styles
+    }
+
+    pub fn set_has_inline_styles(&mut self, value: bool) {
+        self.has_inline_styles = value;
     }
 }
 


### PR DESCRIPTION
This PR fixes issue #17 by modifying the CSS inlining logic to only apply when inline styles are present. It also simplifies the style rendering implementation for better clarity and maintainability.